### PR TITLE
Fix path handling under Windows

### DIFF
--- a/lib/cli.js
+++ b/lib/cli.js
@@ -9,6 +9,8 @@ Cli = (function() {
 
   CliObject.prototype.parseCommandLineArgs = function() {
     var filename = this.args[0];
+    filename = path.normalize(filename);
+
     var templateName = filename.toString().split(path.sep + 'templates' + path.sep).reverse()[0].replace('.handlebars', '').replace('.hbs', '');
 
     templateName = templateName.replace(path.sep, '/');

--- a/tests/cli.spec.js
+++ b/tests/cli.spec.js
@@ -34,4 +34,13 @@ describe("CommandLineParser Tests", function() {
     expect(result['name']).toEqual('tables/other');
   });
 
+  it("returns template content and name when a path is used that is not normalized for the current operating system",
+      function() {
+        var tpl = './file-system/app/templates/tables/other.hbs'
+        var sut = new Cli({args:[tpl]});
+        result = sut.parseCommandLineArgs();
+        expect(result['content']).toEqual('{{outlet}}' + os.EOL);
+        expect(result['name']).toEqual('tables/other');
+      });
+
 });


### PR DESCRIPTION
**commit 4c7716c**

Some tests failed under the windows operating system, because the comparison of

> actual: {{outlet}}**\r\n**
> expected: {{outlet}}**\n**

failed. This can be fixed by using the `os.EOL` constant.

---

**commit 7319849**

Karma seems to pass file paths to its preprocessors using forward slashes regardless of the current operating system. When I use 

```
files: [
  ....
  'templates/*.handlebars'
  ....
],
```

in my karma.conf.js under Windows, karma-ember-preprocessor receives the path E:/.../.../templates/application.handlebars. During processing it tries to split the path by `path.sep + '/templates/' + path.sep`. This fails because the Regex does not match.

The proposed change fixes this problem, since it first normalizes the path and then processes it. 
