### PR TITLE
configurable ember template compiler path

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,19 @@ Next you need to create a configuration file using karma init
         });
     };
 
+In case you want to use your custom Ember template compiler, you can specify path for it in the preprocessor configuration
+    
+    module.exports = function(karma) {
+        karma.set({
+
+            ...
+
+            emberPreprocessor: {
+                compilerPath: 'bower_components/ember/ember-template-compiler.js'
+            }
+        });
+    };
+
 Processed templates will made available in Ember.TEMPLATES. For example:
 
     templates/parent.hbs // => Ember.TEMPLATES['parent']

--- a/lib/main.js
+++ b/lib/main.js
@@ -2,8 +2,8 @@
 
   require('./cli');
 
-  var createEmberPreprocessor = function(logger, basePath) {
-    var compiler = require('ember-template-compiler');
+  var createEmberPreprocessor = function(logger, config) {
+    var compiler = require(config && config.compilerPath ? config.compilerPath : 'ember-template-compiler');
     var log = logger.create('preprocessor.ember');
 
     return function(content, file, done) {
@@ -23,7 +23,7 @@
     };
   };
 
-  createEmberPreprocessor.$inject = ['logger', 'config.basePath'];
+  createEmberPreprocessor.$inject = ['logger', 'config.emberPreprocessor'];
 
   module.exports = {
     'preprocessor:ember': ['factory', createEmberPreprocessor]

--- a/tests/compiler.spec.js
+++ b/tests/compiler.spec.js
@@ -1,0 +1,66 @@
+var path = require('path');
+
+describe("Compiler path configuration tests", function() {
+  var createPreprocessor, mockLogger;
+  beforeEach(function() {
+    createPreprocessor = require('../lib/main')['preprocessor:ember'][1];
+    mockLogger = {
+      create: function() {
+        return {
+          error: function() {
+            throw new Error(util.format.apply(util, arguments));
+          },
+          warn: function() {
+            return null;
+          },
+          info: function() {
+            return null;
+          },
+          debug: function() {
+            return null;
+          }
+        };
+      }
+    }; 
+  });
+
+  it("compiles template with default compiler", function() {
+    var compiledTemplate = '';
+    var process          = createPreprocessor(mockLogger, {});
+
+    process(null, {
+      originalPath: path.join('file-system', 'app', 'templates', 'foo.handlebars')
+    }, function(template) {
+      compiledTemplate = template;          
+    });
+    expect(compiledTemplate).toContain("Ember.TEMPLATES['foo'] = Ember.Handlebars.template");
+  });
+
+  it("compiles template with custom compiler", function() {
+    var compiledTemplate = '';
+    var process          = createPreprocessor(mockLogger, {
+      compilerPath: '../node_modules/ember-template-compiler/vendor/ember-template-compiler'
+    });
+
+    process(null, {
+      originalPath: path.join('file-system', 'app', 'templates', 'foo.handlebars')
+    }, function(template) {
+      compiledTemplate = template;          
+    });
+    expect(compiledTemplate).toContain("Ember.TEMPLATES['foo'] = Ember.Handlebars.template");      
+  });
+
+  it("fails with no custom compiler found", function() {
+    var compilerExecuted = false;
+    try {
+      var process  = createPreprocessor(mockLogger, {
+        compilerPath: 'notExistingCompilerPath'
+      });
+      // should never reach next line
+      compilerExecuted = true;          
+    } catch(err) {
+      expect(err.code).toEqual('MODULE_NOT_FOUND');
+    }
+    expect(compilerExecuted).toBe(false);  
+  });
+});


### PR DESCRIPTION
Could you please pull this into your base so users will be able to use custom ember template compiler in case they want to use it from bower with the newest Ember.

Example of configuration in karma.conf.js:
```
emberPreprocessor: {
    compilerPath: 'bower_components/ember/ember-template-compiler.js'
}
```

It works fine. I tested it with Ember 1.13.5.