### PR TITLE
moved ember-template-compiler to optionalDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,10 +29,10 @@
   "dependencies": {
   },
   "peerDependencies": {
-    "karma": ">=0.9"
+    "karma": ">=0.9",
+    "ember-template-compiler": "1.6.1"
   },
   "devDependencies": {},
   "optionalDependencies": {
-    "ember-template-compiler": "1.6.1"
   }
 }

--- a/package.json
+++ b/package.json
@@ -27,10 +27,10 @@
     "MIT"
   ],
   "dependencies": {
-    "ember-template-compiler": "1.6.1"
   },
   "peerDependencies": {
-    "karma": ">=0.9"
+    "karma": ">=0.9",
+    "ember-template-compiler": "1.6.1"
   },
   "devDependencies": {},
   "optionalDependencies": {}

--- a/package.json
+++ b/package.json
@@ -29,9 +29,10 @@
   "dependencies": {
   },
   "peerDependencies": {
-    "karma": ">=0.9",
-    "ember-template-compiler": "1.6.1"
+    "karma": ">=0.9"
   },
   "devDependencies": {},
-  "optionalDependencies": {}
+  "optionalDependencies": {
+    "ember-template-compiler": "1.6.1"
+  }
 }

--- a/package.json
+++ b/package.json
@@ -29,10 +29,10 @@
   "dependencies": {
   },
   "peerDependencies": {
-    "karma": ">=0.9",
-    "ember-template-compiler": "1.6.1"
+    "karma": ">=0.9"
   },
   "devDependencies": {},
   "optionalDependencies": {
+    "ember-template-compiler": "1.6.1"
   }
 }


### PR DESCRIPTION
Hi again,

could you please merge this change to your head and release new version?

The change contains just package.json update where I moved ember-template-compiler dependency from dependencies to optionalDependencies. 
This is needed in case someone will want to use custom ember preprocessor specified by new option emberPreprocessor and so dependency to ember-template-compiler is not required.

Thanks.