### PR TITLE
Added possibility to transform template name with own function

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 node_modules/
+.idea

--- a/README.md
+++ b/README.md
@@ -58,6 +58,20 @@ In case you want to use your custom Ember template compiler, you can specify pat
             }
         });
     };
+    
+It is also possible to specify a transform function to be used for the template name.
+
+    module.exports = function(karma) {
+            karma.set({
+                ...
+                emberPreprocessor: {
+                    nameTransform: function(templateName) {
+                        // your transform function code
+                        return transformedName;
+                    }
+                }
+            });
+        };
 
 Processed templates will made available in Ember.TEMPLATES. For example:
 

--- a/lib/cli.js
+++ b/lib/cli.js
@@ -7,16 +7,23 @@ Cli = (function() {
     this.args = params.args;
   };
 
+  CliObject.prototype.getTemplateName = function(filename) {
+      var templateName = filename;
+      var nameTransform = this.args[1];
+      if (typeof nameTransform === 'function') {
+          return nameTransform(templateName);
+      }
+      templateName = templateName.split(path.sep + 'templates' + path.sep).reverse()[0].replace('.handlebars', '').replace('.hbs', '');
+      while (path.sep != '/' && templateName.indexOf(path.sep) >= 0) {
+          templateName = templateName.replace(path.sep, '/');
+      }
+      return templateName;
+  };
+
   CliObject.prototype.parseCommandLineArgs = function() {
     var filename = this.args[0];
     filename = path.normalize(filename);
-
-    var templateName = filename.toString().split(path.sep + 'templates' + path.sep).reverse()[0].replace('.handlebars', '').replace('.hbs', '');
-
-    while (path.sep != '/' && templateName.indexOf(path.sep) >= 0) {
-        templateName = templateName.replace(path.sep, '/');
-    }
-
+    var templateName = this.getTemplateName(filename.toString());
     var template = fs.readFileSync(filename.toString(), 'utf8');
     return {'name': templateName, 'content': template};
   };

--- a/lib/main.js
+++ b/lib/main.js
@@ -12,7 +12,7 @@
       log.debug('Processing "%s".', file.originalPath);
 
       try {
-        var template = new Cli({args: [file.originalPath]}).parseCommandLineArgs();
+        var template = new Cli({args: [file.originalPath, config.nameTransform]}).parseCommandLineArgs();
         var input = compiler.precompile(template['content']).toString();
         var processed = "Ember.TEMPLATES['" + template['name'] + "'] = Ember.Handlebars.template(" + input + ");";
       } catch (e) {

--- a/tests/cli.spec.js
+++ b/tests/cli.spec.js
@@ -51,4 +51,15 @@ describe("CommandLineParser Tests", function() {
         expect(result['name']).toEqual('tables/other');
       });
 
+  it('returns template name from transform function', function () {
+    var tpl = path.join('file-system', 'app', 'templates', 'tables', 'child', 'index.handlebars');
+    function trFn(templateName) {
+      return 'foo/' + templateName.replace(/\\/g, '/').split('/')[4];
+    }
+    var sut = new Cli({args: [tpl, trFn]});
+    result = sut.parseCommandLineArgs();
+    expect(result['content']).toEqual('{{outlet}}' + os.EOL);
+    expect(result['name']).toEqual('foo/child');
+  });
+
 });

--- a/tests/compiler.spec.js
+++ b/tests/compiler.spec.js
@@ -7,7 +7,8 @@ describe("Compiler path configuration tests", function() {
     mockLogger = {
       create: function() {
         return {
-          error: function() {
+          error: function(err) {
+            console.log(arguments);
             throw new Error(util.format.apply(util, arguments));
           },
           warn: function() {
@@ -63,4 +64,19 @@ describe("Compiler path configuration tests", function() {
     }
     expect(compilerExecuted).toBe(false);  
   });
+
+    it("process templates with custom template name", function() {
+        var compiledTemplate = '';
+        var process          = createPreprocessor(mockLogger, {
+          nameTransform: function nameTransform() {
+            return 'customTemplateName';
+        }});
+
+        process(null, {
+            originalPath: path.join('file-system', 'app', 'templates', 'foo.handlebars')
+        }, function(template) {
+            compiledTemplate = template;
+        });
+        expect(compiledTemplate).toContain("Ember.TEMPLATES['customTemplateName'] = Ember.Handlebars.template");
+    });
 });

--- a/tests/compiler.spec.js
+++ b/tests/compiler.spec.js
@@ -8,7 +8,6 @@ describe("Compiler path configuration tests", function() {
       create: function() {
         return {
           error: function(err) {
-            console.log(arguments);
             throw new Error(util.format.apply(util, arguments));
           },
           warn: function() {
@@ -65,18 +64,18 @@ describe("Compiler path configuration tests", function() {
     expect(compilerExecuted).toBe(false);  
   });
 
-    it("process templates with custom template name", function() {
-        var compiledTemplate = '';
-        var process          = createPreprocessor(mockLogger, {
-          nameTransform: function nameTransform() {
-            return 'customTemplateName';
-        }});
+  it("process templates with custom template name", function() {
+    var compiledTemplate = '';
+    var process          = createPreprocessor(mockLogger, {
+      nameTransform: function nameTransform() {
+        return 'customTemplateName';
+    }});
 
-        process(null, {
-            originalPath: path.join('file-system', 'app', 'templates', 'foo.handlebars')
-        }, function(template) {
-            compiledTemplate = template;
-        });
-        expect(compiledTemplate).toContain("Ember.TEMPLATES['customTemplateName'] = Ember.Handlebars.template");
+    process(null, {
+      originalPath: path.join('file-system', 'app', 'templates', 'foo.handlebars')
+    }, function(template) {
+      compiledTemplate = template;
     });
+    expect(compiledTemplate).toContain("Ember.TEMPLATES['customTemplateName'] = Ember.Handlebars.template");
+  });
 });

--- a/tests/compiler.spec.js
+++ b/tests/compiler.spec.js
@@ -7,7 +7,7 @@ describe("Compiler path configuration tests", function() {
     mockLogger = {
       create: function() {
         return {
-          error: function(err) {
+          error: function() {
             throw new Error(util.format.apply(util, arguments));
           },
           warn: function() {
@@ -66,7 +66,7 @@ describe("Compiler path configuration tests", function() {
 
   it("process templates with custom template name", function() {
     var compiledTemplate = '';
-    var process          = createPreprocessor(mockLogger, {
+    var process = createPreprocessor(mockLogger, {
       nameTransform: function nameTransform() {
         return 'customTemplateName';
     }});


### PR DESCRIPTION
Hi,

I know this is very old plugin but we still use it in our company because we can't migrate to Ember CLI.
I implemented there support to specify custom transform function for the template name which we need.
Can you please review it and merge it if it's fine?

Thanks,
Fero